### PR TITLE
"issues: write" is needed when PR is created by external users?

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ permissions:
   contents: read # for checkout repository
   actions: read # for fetching base branch bundle stats
   pull-requests: write # for comments
+  issues: write # for comments
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ permissions:
   contents: read # for checkout repository
   actions: read # for fetching base branch bundle stats
   pull-requests: write # for comments
+  issues: write # for comments
 
 jobs:
   build:
@@ -81,6 +82,7 @@ permissions:
   contents: read # for checkout repository
   actions: read # for fetching base branch bundle stats
   pull-requests: write # for comments
+  issues: write # for comments
 ```
 
 ## Action inputs


### PR DESCRIPTION
Attempt to fix https://github.com/exoego/esbuild-bundle-analyzer/pull/28#issuecomment-2128891761