### PR TITLE
fix: correct variable name for show_no_change in action.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -54,7 +54,7 @@ inputs:
     default: "true"
     description: |
       If `true`, a collapsed "details" section is rendered. It explains the details of the numbers provided and icons.
-  show_no_change_bundles:
+  show_no_change:
     required: false
     default: "true"
     description: |


### PR DESCRIPTION
The action.yaml has incorrect variable name for `show_no_change`
