### PR TITLE
chore: group rstest dependency updates into one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,11 @@
     "config:recommended"
   ],
   "labels": ["dependencies"],
-  "minimumReleaseAge": "7 days"
+  "minimumReleaseAge": "7 days",
+  "packageRules": [
+    {
+      "groupName": "rstest packages",
+      "matchPackageNames": ["@rstest/**"]
+    }
+  ]
 }


### PR DESCRIPTION
`@rstest/core` and `@rstest/coverage-v8` are released together, so group their Renovate PRs into one.

```json
{
  "groupName": "rstest packages",
  "matchPackageNames": ["@rstest/**"]
}
```

Verified with `renovate-config-validator`.