### PR TITLE
fix: emit lcov coverage report for Codecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 out
 .analyzer
 tmp/meta.json
+coverage
 
 # Allow-list
 !__tests__/__fixtures__/**/.analyzer/base/bundle/bundle_analysis.json

--- a/rstest.config.ts
+++ b/rstest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
 	reporters: ["verbose"],
 	coverage: {
 		provider: "v8",
-		reporters: ["text"],
+		reporters: ["text", "lcov"],
 	},
 	exclude: ["**/__fixtures__/**"],
 });


### PR DESCRIPTION
## Problem

Codecov upload has been failing since the rstest migration.

```
info -- Found 0 coverage files to report
Error: No coverage reports found. Please make sure you're generating reports successfully.
```

`rstest.config.ts` sets `coverage.reporters` to `["text"]`. The `text` reporter only prints a table to stdout and writes no file, so Codecov finds nothing to upload. The previous `vitest.config.ts` used `reporter: ['lcov']`.

## Fix

Add the `lcov` reporter back. `text` is kept so the summary still shows in the job log.

Verified locally that `npm run test:run` now writes `coverage/lcov.info`.

Also add `coverage` to `.gitignore`.